### PR TITLE
chore: fix semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "patch": "npm version patch && npm publish",
     "minor": "npm version minor && npm publish",
     "major": "npm version major && npm publish",
-    "postpublish": "git push origin master --follow-tags",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {


### PR DESCRIPTION
stray 'postpublish' tried to push to github from CI, which of course is unauthorised
