### PR TITLE
chore(travis): disable matrix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
     - node_modules
 node_js:
   - '4'
-  - '0.12'
-  - '0.10'
 
 before_install:
   - npm i -g npm@^2.0.0


### PR DESCRIPTION
npm does not like parallel publishes (race condition), and travis does not have an `after_all` hook. _sigh_
